### PR TITLE
added ability to accept any color palette, rather than just the ones nam...

### DIFF
--- a/R/mvtsplot.R
+++ b/R/mvtsplot.R
@@ -302,7 +302,12 @@ mvtsplot <- function(x, group = NULL, xtime = NULL,
                 if(margin)
                         colm <- colm[, !empty]
         }
-        pal <- colorRampPalette(brewer.pal(4, palette))
+        if(length(palette)==1) 
+          # an RColorBrewer palette
+          pal <- colorRampPalette(brewer.pal(4, palette))
+        else
+          # a generic brewer.pal object (vector of colors)
+          pal <- colorRampPalette(palette)
 
         nlevels <- if(length(levels) == 1)
                 levels


### PR DESCRIPTION
...ed by RColorBrewer

this makes it possible to make your own palettes, or reverse the order of RColorBrewer palettes. (e.g., if using "RdBu" for plotting temperature, "cold" values showed up  red, which was counterintuitive)
# Examples:

mvtsplot(matrix(runif(99), ncol=9), palette = rev(brewer.pal(4, "RdBu")))
mvtsplot(matrix(runif(99), ncol=9), palette = "RdBu")
mvtsplot(matrix(runif(99), ncol=9), palette = c("#000000","EFFFFFF"))
